### PR TITLE
Add "Viewer Above Other Apps" menu item

### DIFF
--- a/PhotoStudioPlayer/AppDelegate.swift
+++ b/PhotoStudioPlayer/AppDelegate.swift
@@ -12,6 +12,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    @objc var viewerAboveOtherApps = false {
+        didSet {
+            NotificationCenter.default.post(name: AppDelegate.AppGlobalStateDidChange, object: self)
+        }
+    }
+
     func applicationDidFinishLaunching(_ aNotification: Notification) {
     }
 }

--- a/PhotoStudioPlayer/Base.lproj/Main.storyboard
+++ b/PhotoStudioPlayer/Base.lproj/Main.storyboard
@@ -396,6 +396,13 @@ DQ
                                                 <action selector="toggleFullScreen:" target="Ady-hI-5gd" id="dU3-MA-1Rq"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="JBn-BL-tys"/>
+                                        <menuItem title="Viewer Above Other Apps" id="XJm-T0-exO" userLabel="Viewer Above Other Apps">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <binding destination="Voe-Tx-rLC" name="value" keyPath="viewerAboveOtherApps" id="Nrt-A4-6p3"/>
+                                            </connections>
+                                        </menuItem>
                                     </items>
                                 </menu>
                             </menuItem>

--- a/PhotoStudioPlayer/ViewController.swift
+++ b/PhotoStudioPlayer/ViewController.swift
@@ -32,6 +32,7 @@ class ViewController: NSViewController, AVCaptureVideoDataOutputSampleBufferDele
 
         NotificationCenter.default.addObserver(forName: AppDelegate.AppGlobalStateDidChange, object: nil, queue: nil) { [weak self] _ in
             self?.readyCaptureFrameIfNeeded()
+            self?.changeWindowLevelIfNeeded()
         }
     }
 
@@ -122,6 +123,14 @@ class ViewController: NSViewController, AVCaptureVideoDataOutputSampleBufferDele
             session?.addOutput(videoDataOutput)
         } else {
             session?.removeOutput(videoDataOutput)
+        }
+    }
+
+    private func changeWindowLevelIfNeeded() {
+        if appDelegate.viewerAboveOtherApps {
+            view.window?.level = .floating
+        } else {
+            view.window?.level = .normal
         }
     }
 


### PR DESCRIPTION
#Because we don't want to miss idol, I added the option to show this player in front of any other apps.

## Menu
Add "Viewer Above Other Apps" option in a "View" menu. This is same position as DVD player.

<img width="300" alt="screen shot 2017-11-05 at 9 33 13" src="https://user-images.githubusercontent.com/9650/32410823-55f33fb4-c20d-11e7-9d26-fdd60662077e.png">

## Implement
Change window level if user switch this option like this:

```swift
if appDelegate.viewerAboveOtherApps {
  view.window?.level = .floating
} else {
  view.window?.level = .normal
}
```

## Screenshot
<img width="901" alt="screen shot 2017-11-05 at 9 46 09" src="https://user-images.githubusercontent.com/9650/32410870-4e428f1c-c20e-11e7-8d0f-aa8a9f56c08d.png">
