### PR TITLE
Multi devices support

### DIFF
--- a/PhotoStudioPlayer/AppDelegate.swift
+++ b/PhotoStudioPlayer/AppDelegate.swift
@@ -49,6 +49,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
 
     @objc private func openWindow(_ sender: NSMenuItem) {
+        guard let uniqueID = sender.representedObject as? String else {
+            return
+        }
+
+        guard let window = NSStoryboard(name: NSStoryboard.Name("Main"), bundle: nil).instantiateInitialController() as? NSWindowController else {
+            return
+        }
+        guard let vc = window.contentViewController as? ViewController else {
+            return
+        }
+        vc.device = self.availableDevices().first { $0.uniqueID == uniqueID }
+        window.showWindow(nil)
     }
 
     private func availableDevices() -> [AVCaptureDevice] {

--- a/PhotoStudioPlayer/AppDelegate.swift
+++ b/PhotoStudioPlayer/AppDelegate.swift
@@ -1,9 +1,13 @@
+import AVFoundation
+import AVKit
 import Cocoa
+import CoreImage
+import CoreMediaIO
 
 let appDelegate = NSApp.delegate as! AppDelegate
 
 @NSApplicationMain
-class AppDelegate: NSObject, NSApplicationDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     static let AppGlobalStateDidChange = NSNotification.Name(rawValue: "AppGlobalStateDidChange")
 
     @objc var enabledCaptureFrame = false {
@@ -19,5 +23,35 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
+        var prop = CMIOObjectPropertyAddress(
+            mSelector: CMIOObjectPropertySelector(kCMIOHardwarePropertyAllowScreenCaptureDevices),
+            mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeGlobal),
+            mElement: CMIOObjectPropertyElement(kCMIOObjectPropertyElementMaster))
+        var allow: UInt32 = 1;
+        CMIOObjectSetPropertyData(CMIOObjectID(kCMIOObjectSystemObject), &prop,
+                                  0, nil,
+                                  UInt32(MemoryLayout.size(ofValue: allow)), &allow)
+    }
+
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        menu.removeAllItems()
+
+        let devices = availableDevices()
+        if devices.isEmpty {
+            menu.addItem(NSMenuItem(title: "<None>", action: nil, keyEquivalent: ""))
+        } else {
+            for device in devices {
+                let menuItem = NSMenuItem(title: device.localizedName, action: #selector(openWindow(_:)), keyEquivalent: "")
+                menuItem.representedObject = device.uniqueID
+                menu.addItem(menuItem)
+            }
+        }
+    }
+
+    @objc private func openWindow(_ sender: NSMenuItem) {
+    }
+
+    private func availableDevices() -> [AVCaptureDevice] {
+        return AVCaptureDevice.devices().filter {$0.hasMediaType(.muxed)}
     }
 }

--- a/PhotoStudioPlayer/AppDelegate.swift
+++ b/PhotoStudioPlayer/AppDelegate.swift
@@ -53,7 +53,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             return
         }
 
-        guard let window = NSStoryboard(name: NSStoryboard.Name("Main"), bundle: nil).instantiateInitialController() as? NSWindowController else {
+        guard let window = NSStoryboard(name: NSStoryboard.Name("Main"), bundle: nil).instantiateController(withIdentifier: NSStoryboard.SceneIdentifier("Window")) as? NSWindowController else {
             return
         }
         guard let vc = window.contentViewController as? ViewController else {

--- a/PhotoStudioPlayer/Base.lproj/Main.storyboard
+++ b/PhotoStudioPlayer/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13529"/>
@@ -466,7 +466,7 @@ DQ
         <!--Window Controller-->
         <scene sceneID="R2V-B0-nI4">
             <objects>
-                <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
+                <windowController storyboardIdentifier="Window" id="B8D-0N-5wS" sceneMemberID="viewController">
                     <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hasShadow="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" titlebarAppearsTransparent="YES" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>

--- a/PhotoStudioPlayer/Base.lproj/Main.storyboard
+++ b/PhotoStudioPlayer/Base.lproj/Main.storyboard
@@ -338,6 +338,14 @@
                                     </items>
                                 </menu>
                             </menuItem>
+                            <menuItem title="Devices" id="NLq-Ir-fVl">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Devices" id="dO0-Ut-G0L">
+                                    <connections>
+                                        <outlet property="delegate" destination="Voe-Tx-rLC" id="CwR-Yz-pDz"/>
+                                    </connections>
+                                </menu>
+                            </menuItem>
                             <menuItem title="Control" id="GV9-8g-wME">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Control" id="tNS-ZI-9Uu">

--- a/PhotoStudioPlayer/ViewController.swift
+++ b/PhotoStudioPlayer/ViewController.swift
@@ -1,10 +1,10 @@
 import Cocoa
-import CoreMediaIO
 import AVFoundation
-import CoreImage
 
 class ViewController: NSViewController, AVCaptureVideoDataOutputSampleBufferDelegate {
-    private var device: AVCaptureDevice?
+    var device: AVCaptureDevice? = nil {
+        didSet { setupPreviewLayer() }
+    }
     private var session: AVCaptureSession?
     private var previewLayer: AVCaptureVideoPreviewLayer? {
         didSet {
@@ -27,8 +27,6 @@ class ViewController: NSViewController, AVCaptureVideoDataOutputSampleBufferDele
     override func viewDidLoad() {
         super.viewDidLoad()
         view.wantsLayer = true
-        fetchScreenRecordingDevice()
-        setupPreviewLayer()
 
         NotificationCenter.default.addObserver(forName: AppDelegate.AppGlobalStateDidChange, object: nil, queue: nil) { [weak self] _ in
             self?.readyCaptureFrameIfNeeded()
@@ -54,21 +52,6 @@ class ViewController: NSViewController, AVCaptureVideoDataOutputSampleBufferDele
 //            w.titleVisibility = .visible
             w.isMovableByWindowBackground = true
         }
-    }
-
-    func fetchScreenRecordingDevice() {
-        var prop = CMIOObjectPropertyAddress(
-            mSelector: CMIOObjectPropertySelector(kCMIOHardwarePropertyAllowScreenCaptureDevices),
-            mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeGlobal),
-            mElement: CMIOObjectPropertyElement(kCMIOObjectPropertyElementMaster))
-        var allow: UInt32 = 1;
-        CMIOObjectSetPropertyData(CMIOObjectID(kCMIOObjectSystemObject), &prop,
-                                  0, nil,
-                                  UInt32(MemoryLayout.size(ofValue: allow)), &allow)
-
-        let devices = AVCaptureDevice.devices().filter {$0.hasMediaType(.muxed)}
-        NSLog("%@", "devices = \(devices)")
-        device = devices.first {$0.hasMediaType(.muxed)}
     }
 
     func setupPreviewLayer() {

--- a/PhotoStudioPlayer/ViewController.swift
+++ b/PhotoStudioPlayer/ViewController.swift
@@ -32,6 +32,19 @@ class ViewController: NSViewController, AVCaptureVideoDataOutputSampleBufferDele
             self?.readyCaptureFrameIfNeeded()
             self?.changeWindowLevelIfNeeded()
         }
+
+        NotificationCenter.default.addObserver(forName: .AVCaptureSessionRuntimeError, object: nil, queue: nil) { n in
+            if n.object as? AVCaptureSession != self.session {
+                return
+            }
+            if let error = n.userInfo?["AVCaptureSessionErrorKey"] as? Error {
+                if let window = self.view.window {
+                    self.presentError(error, modalFor: window, delegate: self, didPresent: #selector(self.closeWindow(_:)), contextInfo: nil)
+                } else {
+                    self.presentError(error)
+                }
+            }
+        }
     }
 
     override func viewDidLayout() {
@@ -123,5 +136,9 @@ class ViewController: NSViewController, AVCaptureVideoDataOutputSampleBufferDele
 
     @IBAction func openCaptureFolder(_ sender: AnyObject?) {
         NSWorkspace.shared.open(captureFolder)
+    }
+
+    @objc private func closeWindow(_ sender: Any) {
+        view.window?.close()
     }
 }

--- a/README.md
+++ b/README.md
@@ -6,10 +6,18 @@ demo video: <https://twitter.com/banjun/status/926332370252263424>
 
 any guidance are not implemented.
 
-* make sure your iPhone is connected to Mac with cable
-* make sure your iPhone is visible as video source in QuickTime Player
-* (re-)launch PhotoStudioPlayer. app lookups video sources only on launch.
-* make sure capture image is blue backed :cool: :eyes:
+1. make sure your iPhone is connected to Mac with cable
+2. make sure your iPhone is visible as video source in QuickTime Player
+3. launch PhotoStudioPlayer
+4. select device from "Devices" menu
+4. make sure capture image is blue backed :cool: :eyes:
+
+## Troble shoots
+### Can't find my iPhone on device menu
+Try to reconnect iPhone, restart app, reboot iPhone.
+
+### "The operation could not be completed" error
+Try to re-create window from "Devices" menu.
 
 ## Contributing
 


### PR DESCRIPTION
Showing idol is great, so showing multi idol is more great.

# Enhance menu
Add device menu and show available devices.

<img width="537" alt="screen shot 2017-11-05 at 21 23 49" src="https://user-images.githubusercontent.com/9650/32414671-a54a1e90-c26f-11e7-9403-78a0ee6009c9.png">

# 📷  Screenshot
<img width="810" alt="screen shot 2017-11-05 at 20 38 58" src="https://user-images.githubusercontent.com/9650/32414627-b6030e1e-c26e-11e7-8d6e-baf6478cacde.png">

# Implement
 * Add menu to select device
 * Show alert sheet when AVCaptureSession's initialization is failed.
 * Stop to create initial window at startup.

# Protip
Because starlight stage doesn't permit multi-session, it is good to keep producer note launched. 

