### PR TITLE
Fix window disappearance when preview started

### DIFF
--- a/PhotoStudioPlayer/AppDelegate.swift
+++ b/PhotoStudioPlayer/AppDelegate.swift
@@ -10,6 +10,8 @@ let appDelegate = NSApp.delegate as! AppDelegate
 class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     static let AppGlobalStateDidChange = NSNotification.Name(rawValue: "AppGlobalStateDidChange")
 
+    private var windowControllers = [NSWindowController]()
+
     @objc var enabledCaptureFrame = false {
         didSet {
             NotificationCenter.default.post(name: AppDelegate.AppGlobalStateDidChange, object: self)
@@ -56,6 +58,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         guard let window = NSStoryboard(name: NSStoryboard.Name("Main"), bundle: nil).instantiateController(withIdentifier: NSStoryboard.SceneIdentifier("Window")) as? NSWindowController else {
             return
         }
+        self.windowControllers.append(window)
+
         guard let vc = window.contentViewController as? ViewController else {
             return
         }


### PR DESCRIPTION
This PR fixes that window disappearance when preview started. 

 I found this bug in **macOS Sierra(10.12.6)**, but it may not occur in **macOS HighSierra**🤔🤔🤔

### solution
I just store the window instance to **AppDelegate** member.  This is like a **first aid**.

<img width="500" alt="screen shot 2017-12-16 at 22 10 13" src="https://user-images.githubusercontent.com/3097559/34070885-689105c0-e2b0-11e7-8df3-b8fd4f6d00ab.png">
