### PR TITLE
Use more strong window level to float on fullscreen app

### DIFF
--- a/PhotoStudioPlayer/ViewController.swift
+++ b/PhotoStudioPlayer/ViewController.swift
@@ -124,7 +124,8 @@ class ViewController: NSViewController, AVCaptureVideoDataOutputSampleBufferDele
 
     private func changeWindowLevelIfNeeded() {
         if appDelegate.viewerAboveOtherApps {
-            view.window?.level = .floating
+            // use .popUpMenu instead of .floating to show on fullscreen app(e.g. Keynote)
+            view.window?.level = .popUpMenu
         } else {
             view.window?.level = .normal
         }


### PR DESCRIPTION
Use more strong window level to show a idol on full-screen app(e.g. Keynote)

![screen shot 2018-06-30 at 23 47 57 2](https://user-images.githubusercontent.com/9650/42126299-f346c74a-7cc0-11e8-8f46-e23d770b7b0a.png)
