### PR TITLE
Archive on Xcode Cloud

### DIFF
--- a/PhotoStudioPlayer/Info.plist
+++ b/PhotoStudioPlayer/Info.plist
@@ -20,6 +20,8 @@
 	<string>0.10.0</string>
 	<key>CFBundleVersion</key>
 	<string>11</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
> ITMS-90242: The product archive is invalid. The Info.plist must contain a LSApplicationCategoryType key, whose value is the UTI for a valid category. For more details, see "Submitting your Mac apps to the App Store".