### PR TITLE
Player Rotation

### DIFF
--- a/PhotoStudioPlayer/Base.lproj/Main.storyboard
+++ b/PhotoStudioPlayer/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19162"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -459,6 +459,18 @@ DQ
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <binding destination="Voe-Tx-rLC" name="value" keyPath="viewerAboveOtherApps" id="Nrt-A4-6p3"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Rotate Left" keyEquivalent="L" id="WA5-SH-c5b">
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="rotateLeft:" target="Ady-hI-5gd" id="yQi-nm-Anc"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Rotate Right" keyEquivalent="R" id="ZbR-CH-KUa">
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="rotateRight:" target="Ady-hI-5gd" id="mbT-pY-MrE"/>
                                             </connections>
                                         </menuItem>
                                     </items>

--- a/PhotoStudioPlayer/CaptureSession.swift
+++ b/PhotoStudioPlayer/CaptureSession.swift
@@ -83,6 +83,7 @@ final class CaptureSession: NSObject, AVCapturePhotoCaptureDelegate {
         guard let pixelBuffer = photo.pixelBuffer else { return }
         let image = CIImage(cvPixelBuffer: pixelBuffer)
         coreImageFilterForCapture?.setValue(image, forKey: kCIInputImageKey)
+        // TODO: apply rotation when the view is rotated on the ViewController
         guard let outputImage = coreImageFilterForCapture?.outputImage else { return }
         let bitmap = NSBitmapImageRep(ciImage: outputImage)
         let png = bitmap.representation(using: .png, properties: [:])

--- a/PhotoStudioPlayer/ViewController.swift
+++ b/PhotoStudioPlayer/ViewController.swift
@@ -13,6 +13,15 @@ class ViewController: NSViewController, AVCaptureVideoDataOutputSampleBufferDele
         }
     }
 
+    private let rotations: [CGFloat] = [0, -.pi / 2, .pi, +.pi / 2]
+    private var rotation: CGFloat = 0 {
+        didSet {
+            session?.previewLayer.transform = CATransform3DMakeRotation(rotation, 0, 0, 1)
+            guard let layer = view.layer else { return }
+            session?.previewLayer.frame = layer.bounds
+        }
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         view.wantsLayer = true
@@ -120,6 +129,14 @@ class ViewController: NSViewController, AVCaptureVideoDataOutputSampleBufferDele
 
     @IBAction func toggleMuted(_ sender: AnyObject?) {
         session?.muted.toggle()
+    }
+
+    @IBAction func rotateLeft(_ sender: AnyObject?) {
+        rotation = rotations[((rotations.firstIndex(of: rotation)?.advanced(by: -1) ?? 0) + rotations.count) % rotations.count]
+    }
+
+    @IBAction func rotateRight(_ sender: AnyObject?) {
+        rotation = rotations[(rotations.firstIndex(of: rotation)?.advanced(by: 1) ?? 0) % rotations.count]
     }
 
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {


### PR DESCRIPTION
Add `Rotate Left` & `Rotate Right` menu item to rotate player to support a source app that make its orientation change without making a corresponding device orientation change.